### PR TITLE
Stop accounts.tfa.email.getEmails call from dropping query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # SAP CDC (Gigya) Android SDK
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/gigya-android-sdk)](https://api.reuse.software/info/github.com/SAP/gigya-android-sdk)
 
+## Atomic Changes vs. Original Repo
+
+This fork contains a bug fix that prevents the Gigya SDK from dropping query parameters
+when making the `accounts.tfa.email.getEmails` call to Gigya
+
 ## Description
 The Android SDK provides an interface for the Gigya API.
 The library makes it simple to integrate Gigya's service in your Android application.

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.10.0' apply false
-    id 'com.android.library' version '8.10.0' apply false
+    id 'com.android.application' version '8.10.1' apply false
+    id 'com.android.library' version '8.10.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.0' apply false
     id 'com.google.gms.google-services' version '4.3.13' apply false
     id 'org.jetbrains.dokka' version '1.9.0' apply false

--- a/sdk-auth/build.gradle
+++ b/sdk-auth/build.gradle
@@ -30,8 +30,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {

--- a/sdk-biometric/build.gradle
+++ b/sdk-biometric/build.gradle
@@ -34,8 +34,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {

--- a/sdk-core/build.gradle
+++ b/sdk-core/build.gradle
@@ -33,8 +33,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {

--- a/sdk-core/src/main/java/com/gigya/android/sdk/containers/GigyaContainer.java
+++ b/sdk-core/src/main/java/com/gigya/android/sdk/containers/GigyaContainer.java
@@ -70,7 +70,7 @@ public class GigyaContainer extends IoCContainer {
                 .bind(IProviderFactory.class, ProviderFactory.class, true)
                 .bind(IBusinessApiService.class, BusinessApiService.class, true)
                 .bind(IOauthService.class, OauthService.class, true)
-                .bind(IFidoApiService.class, Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? FidoApiServiceV23Impl.class : FidoApiServiceImpl.class, true)
+                .bind(IFidoApiService.class, FidoApiServiceV23Impl.class, true)
                 .bind(IWebAuthnService.class, WebAuthnService.class, true)
                 .bind(ISaptchaService.class, SaptchaService.class, false)
                 .bind(IWebViewFragmentFactory.class, WebViewFragmentFactory.class, false)

--- a/sdk-tfa/build.gradle
+++ b/sdk-tfa/build.gradle
@@ -31,8 +31,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {

--- a/sdk-tfa/src/main/java/com/gigya/android/sdk/tfa/resolvers/email/RegisteredEmailsResolver.java
+++ b/sdk-tfa/src/main/java/com/gigya/android/sdk/tfa/resolvers/email/RegisteredEmailsResolver.java
@@ -83,7 +83,7 @@ public class RegisteredEmailsResolver<A extends GigyaAccount> extends TFAResolve
     private void fetchEmails(@NonNull final ResultCallback resultCallback) {
         final Map<String, Object> params = new HashMap<>();
         params.put("gigyaAssertion", _gigyaAssertion);
-        _businessApiService.send(GigyaDefinitions.API.API_TFA_EMAIL_GET_EMAILS, params, RestAdapter.GET,
+        _businessApiService.send(GigyaDefinitions.API.API_TFA_EMAIL_GET_EMAILS, params, RestAdapter.POST,
                 GetEmailsModel.class, new GigyaCallback<GetEmailsModel>() {
                     @Override
                     public void onSuccess(GetEmailsModel model) {


### PR DESCRIPTION
As part of the 2FA process, we need to retrieve the list of emails that a 2FA code can be sent to for the signed in user before triggering Gigya to send the email itself

The current latest version of the Gigya SDK contains a bug that prevents the `accounts.tfa.email.getEmails` call (which is used for retrieving the user's email addresses for 2FA) from sending the request with the query parameters it needs, resulting in every response coming back with the following error

```
{
  "callId" : "ebbfd50bcca147ca8888742fbef4209c",
  "errorCode" : 400002,
  "errorDetails" : "gigyaAssertion cannot be nul",
  "errorMessage" : "Missing required parameter",
  "apiVersion" : 2,
  "statusCode" : 400,
  "statusReason" : "Bad Request",
  "time" : "2025-08-29T11:25:26.652Z"
}
```

Changing this API call to a POST call means the correct query parameters are sent (handled in HttpNetworkProvider.java line 209), and we are able to get the email(s) necessary to trigger a 2FA code be sent