### PR TITLE
Fix compile-time issue in GigyaBiometric

### DIFF
--- a/sdk-biometric/src/main/java/com/gigya/android/sdk/biometric/GigyaBiometric.java
+++ b/sdk-biometric/src/main/java/com/gigya/android/sdk/biometric/GigyaBiometric.java
@@ -32,9 +32,11 @@ public class GigyaBiometric {
 
             container.bind(GigyaBiometric.class, GigyaBiometric.class, true);
 
+            var biometricImpl = GigyaBiometricUtils.isPromptEnabled() ? BiometricImplV28.class : BiometricImplV23.class;
+
             // Set the relevant biometric implementation according to Android API level.
             container.bind(BiometricImpl.class,
-                    GigyaBiometricUtils.isPromptEnabled() ? BiometricImplV28.class : BiometricImplV23.class,
+                    biometricImpl,
                     true);
 
             try {


### PR DESCRIPTION
This fixes a compile-time issue caused by updating the JDK version, which is causing linters to fail when this is imported